### PR TITLE
Add bower.json to add development dependency on Jasmine 1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
 .idea
 atlassian-ide-plugin.xml
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+	"name": "conference-schedule",
+	"version": "0.1.0",
+	"homepage": "https://github.com/glaubinix/conference-schedule",
+	"description": "A cross-device conference schedule app.",
+	"main": "index.html",
+	"keywords": [
+		"conference",
+		"schedule"
+	],
+	"license": "MIT",
+	"private": true,
+	"devDependencies": {
+		"jasmine": "1.3.1"
+	}
+}
+


### PR DESCRIPTION
Not sure if you guys want to use Bower but in case you do, here's a bower.json to add Jasmine as a dependency.
I didn't know which version the conf schedule currently has, so I went ahead and picked 0.1.0.
Bower expects the versioning to adhere to SemVer.

Anyways, if you have bower installed, Jasmine will be installed with "bower install".
