### PR TITLE
make it possible to init conference-schedule via dataset

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">
     </head>
-    <body>
+    <body data-config="">
 		<h1 id="headline"></h1>
 		<ul id="schedule-tabs"></ul>
 		<div id="schedule"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -6,10 +6,18 @@
 	var page_builder = new PageBuilder(emitter, view_helper);
 	page_builder.registerEvents();
 
-	var request = new Request('config.json');
-	request.load(function(raw_config) {
-		var config = JSON.parse(raw_config);
+	var raw_config = document.body.dataset['config'];
+	if (raw_config) {
+		display(raw_config)
+	} else {
+		var request = new Request('config.json');
+		request.load(function(raw_config) {
+			display(raw_config);
+		});
+	}
 
+	function display(raw_config) {
+		var config = JSON.parse(raw_config);
 		var theme_loader = new ThemeLoader();
 		theme_loader.loadTheme(config.theme);
 
@@ -38,6 +46,6 @@
 				emitter.trigger('schedule-data-ready', result);
 			});
 		}
-	});
+	}
 
 })();


### PR DESCRIPTION
This would enable two things
-builder: reload the iframe while simply passing the config on reload and dynamically pasting it into the html on the server side. This would make the entire iframe communication not necessary :)
-build process: simply replace the empty data content with the json string config (should we really want that)
