### PR TITLE
remove hardcoded gid

### DIFF
--- a/js/schedule-loader.js
+++ b/js/schedule-loader.js
@@ -30,7 +30,7 @@ JsonScheduleLoader.prototype = new ScheduleLoader();
 JsonScheduleLoader.prototype.constructor = JsonScheduleLoader;
 
 function SpreadsheetScheduleLoader(key) {
-	this.url = "https://docs.google.com/spreadsheet/pub?key=" + key + "&single=true&gid=1&output=csv";
+	this.url = "https://docs.google.com/spreadsheet/pub?key=" + key + "&single=true&output=csv";
 }
 
 SpreadsheetScheduleLoader.prototype = new ScheduleLoader();


### PR DESCRIPTION
some spreadsheets have different gids, so do not hardcode it

example url:

https://docs.google.com/a/kowalski.gd/spreadsheet/ccc?key=0AqTI4yNHbPV6dDYtZ3NEeEVEbGxGS3FwamhwbGxhcXc&usp=drive_web#gid=0
